### PR TITLE
test-reporterの導入とカバレッジレポートの保存

### DIFF
--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           reports: '**/TestResults/coverage.cobertura.xml'
           targetdir: 'CoverageReport'
-          reporttypes: 'MarkdownSummaryGithub;Html'
+          reporttypes: 'MarkdownSummaryGithub;TextSummary'
     
       - name: コードカバレッジの結果表示
         shell: bash
@@ -135,7 +135,7 @@ jobs:
           name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
           path: |
             tests/Maris.Logging.Testing.Tests/**/TestResults/
-            CoverageReport/index.html
+            CoverageReport/Summary.txt
   
       - name: 単体テスト結果の確認
         if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -102,13 +102,13 @@ jobs:
           max-annotations: '10'
           fail-on-error: 'false'
           fail-on-empty: 'true'
-    
+
       - id: create-coverage-report
         name: コードカバレッジレポートの解析
         uses: danielpalme/ReportGenerator-GitHub-Action@5
         with:
           reports: '**/TestResults/coverage.cobertura.xml'
-          targetdir: 'CoverageReport'
+          targetdir: 'CoverageReport;Html'
           reporttypes: 'MarkdownSummaryGithub'
     
       - name: コードカバレッジの結果表示
@@ -135,6 +135,13 @@ jobs:
           name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
           path: tests/Maris.Logging.Testing.Tests/**/TestResults/
 
+      - name: カバレッジレポートのアップロード
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
+          path: CoverageReport/
+  
       - name: 単体テスト結果の確認
         if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}
         run: exit 1
+        

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -108,8 +108,8 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@5
         with:
           reports: '**/TestResults/coverage.cobertura.xml'
-          targetdir: 'CoverageReport;Html'
-          reporttypes: 'MarkdownSummaryGithub'
+          targetdir: 'CoverageReport'
+          reporttypes: 'MarkdownSummaryGithub;Html'
     
       - name: コードカバレッジの結果表示
         shell: bash

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -134,7 +134,6 @@ jobs:
         with:
           name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
           path: tests/Maris.Logging.Testing.Tests/**/TestResults/
-          retention-days: 1
 
       - name: 単体テスト結果の確認
         if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -133,13 +133,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
-          path: tests/Maris.Logging.Testing.Tests/**/TestResults/
-
-      - name: カバレッジレポートのアップロード
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-results-${{ matrix.vm_image }}-${{ matrix.framework_version }}
-          path: CoverageReport/
+          path: |
+            tests/Maris.Logging.Testing.Tests/**/TestResults/
+            CoverageReport/index.html
   
       - name: 単体テスト結果の確認
         if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -84,21 +84,24 @@ jobs:
         continue-on-error: true
         run: |
           echo '## Test Result :memo:' >> $GITHUB_STEP_SUMMARY
-          dotnet test tests/Maris.Logging.Testing.Tests/ --no-build --nologo --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework_version }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx --report-xunit-trx-filename ${{ matrix.vm_image }}-${{ matrix.framework_version }}.trx > unit-test-result.txt
-          echo ':heavy_check_mark: アプリケーションの単体テストに成功しました。' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat unit-test-result.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          dotnet test tests/Maris.Logging.Testing.Tests/ --no-build --nologo --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework_version }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx --report-xunit-trx-filename ${{ matrix.vm_image }}-${{ matrix.framework_version }}.trx
 
-      - name: 単体テスト失敗時の結果表示
-        shell: bash
-        if: ${{ steps.run-unit-test.outcome == 'failure' }}
-        run: |
-          echo ':x: アプリケーションの単体テストに失敗しました。  ' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat unit-test-result.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo 'TEST_STATUS=Error' >> $GITHUB_ENV
+      - id: create-test-result-report
+        name: テスト結果ページの作成
+        uses: dorny/test-reporter@v2
+        with:
+          name: 'Test results ${{ matrix.framework_version }} on ${{ matrix.vm_image }}'
+          path: '**/TestResults/${{ matrix.vm_image }}-${{ matrix.framework_version }}.trx'
+          path-replace-backslashes: 'true'
+          reporter: 'dotnet-trx'
+          only-summary: 'false'
+          use-actions-summary: 'true'
+          badge-title: 'tests'
+          list-suites: 'failed'
+          list-tests: 'failed'
+          max-annotations: '10'
+          fail-on-error: 'false'
+          fail-on-empty: 'true'
     
       - id: create-coverage-report
         name: コードカバレッジレポートの解析
@@ -134,5 +137,5 @@ jobs:
           retention-days: 1
 
       - name: 単体テスト結果の確認
-        if: ${{ env.TEST_STATUS == 'Error' }}
+        if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}
         run: exit 1


### PR DESCRIPTION
## この Pull request で実施したこと

テスト結果の表示用にtest-reporterを導入しました。
テスト結果の保存期間を既定値に変更しました。
カバレッジレポートを保存するようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://github.com/tsuna-can-se/hello-world/pull/75>