### PR TITLE
依存ライブラリのバージョンを8系の古いものに変更する

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />


### PR DESCRIPTION
## この Pull request で実施したこと

ライブラリというの性質上、最新バージョンを追いかける必要はないため、.NET 8系の最初のリリースを対象に変更しました。
パッケージングすると、このバージョン以降の任意のバージョンを利用できるようになるため、利用者側で最新を追いかけることは可能です。

推移パッケージで直接参照していなかった `Microsoft.Extensions.Logging.Abstraction` を Directory.Package.props から削除しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし