### PR TITLE
リリースノートからMaris.Logging.Testingのnuget.orgページへのリンクを追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   categories:
-    - title: ':newspaper: Maris.Logging.Testing features'
+    - title: ':newspaper: [Maris.Logging.Testing](https://www.nuget.org/packages/Maris.Logging.Testing) features'
       labels:
         - 'target: Maris.Logging.Testing'
       exclude:


### PR DESCRIPTION
## この Pull request で実施したこと

リリースノートのページから、nuget.orgのパッケージのページにリンクするようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし