### PR TITLE
Maris.Logging.Testingを.NET Fw 4.7.2, .NET 9.0 に対応させる

### DIFF
--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -26,7 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         vm_image: [ubuntu-latest, windows-latest, macos-latest]
-        framework_version: [net8.0, net9.0]
+        framework_version: [net48, net8.0, net9.0]
+        exclude:
+         - vm_image: ubuntu-latest
+           framework_version: net48
+         - vm_image: macos-latest
+           framework_version: net48
 
     runs-on: ${{ matrix.vm_image }}
    

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            4.8.x
             8.0.x
             9.0.x
           dotnet-quality: 'ga'

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -50,7 +50,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            4.8.x
             8.0.x
             9.0.x
           dotnet-quality: 'ga'

--- a/.github/workflows/maris-logging-testing.ci.yml
+++ b/.github/workflows/maris-logging-testing.ci.yml
@@ -26,12 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         vm_image: [ubuntu-latest, windows-latest, macos-latest]
-        framework_version: [net48, net8.0, net9.0]
+        framework_version: [net472, net8.0, net9.0]
         exclude:
          - vm_image: ubuntu-latest
-           framework_version: net48
+           framework_version: net472
          - vm_image: macos-latest
-           framework_version: net48
+           framework_version: net472
 
     runs-on: ${{ matrix.vm_image }}
    

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Copyright>Copyright © 2025 BIPROGY Inc. All rights reserved.</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,13 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Copyright>Copyright © 2025 BIPROGY Inc. All rights reserved.</Copyright>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <LangVersion>latest</LangVersion>
+    <RuntimeIdentifiers>win-x86;win-x64;osx-arm64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Copyright>Copyright © 2025 BIPROGY Inc. All rights reserved.</Copyright>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.5.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
-    <PackageVersion Include="Mono.Cecil" Version="0.11.5.0" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
-    <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
 </Project>

--- a/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
+++ b/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
@@ -15,6 +15,7 @@
     <RepositoryUrl>https://github.com/AlesInfiny/dotnet-libraries.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
+++ b/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
@@ -15,8 +15,6 @@
     <RepositoryUrl>https://github.com/AlesInfiny/dotnet-libraries.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
-    <NoWarn>NU1701</NoWarn>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
+++ b/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
@@ -15,6 +15,8 @@
     <RepositoryUrl>https://github.com/AlesInfiny/dotnet-libraries.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
+    <NoWarn>NU1701</NoWarn>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Maris.Logging.Testing/Xunit/FakeLoggingBuilderExtensions.cs
+++ b/src/Maris.Logging.Testing/Xunit/FakeLoggingBuilderExtensions.cs
@@ -22,8 +22,16 @@ public static class FakeLoggingBuilderExtensions
     /// </exception>
     public static ILoggingBuilder AddFakeLogging(this ILoggingBuilder builder, TestLoggerManager loggerManager)
     {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(loggerManager);
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (loggerManager is null)
+        {
+            throw new ArgumentNullException(nameof(loggerManager));
+        }
+
         builder.AddProvider(loggerManager.FakeLoggerProvider);
         return builder;
     }

--- a/src/Maris.Logging.Testing/Xunit/TestLoggerServiceCollectionExtensions.cs
+++ b/src/Maris.Logging.Testing/Xunit/TestLoggerServiceCollectionExtensions.cs
@@ -22,8 +22,16 @@ public static class TestLoggerServiceCollectionExtensions
     /// </exception>
     public static IServiceCollection AddTestLogging(this IServiceCollection services, TestLoggerManager loggerManager)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(loggerManager);
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (loggerManager is null)
+        {
+            throw new ArgumentNullException(nameof(loggerManager));
+        }
+
         services.AddLogging(builder =>
         {
             builder.AddXunitLogging(loggerManager);

--- a/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
+++ b/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
@@ -27,7 +27,11 @@ internal class XunitLoggerProvider : ILoggerProvider, IDisposable
     /// <inheritdoc/>
     public ILogger CreateLogger(string categoryName)
     {
-        ObjectDisposedException.ThrowIf(this.testOutputHelper is null, this);
+        if (this.testOutputHelper is null)
+        {
+            throw new ObjectDisposedException(this.GetType().ToString());
+        }
+
         return new XunitLogger(this.testOutputHelper, categoryName);
     }
 

--- a/src/Maris.Logging.Testing/Xunit/XunitLoggingBuilderExtensions.cs
+++ b/src/Maris.Logging.Testing/Xunit/XunitLoggingBuilderExtensions.cs
@@ -21,8 +21,16 @@ public static class XunitLoggingBuilderExtensions
     /// </exception>
     public static ILoggingBuilder AddXunitLogging(this ILoggingBuilder builder, TestLoggerManager loggerManager)
     {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(loggerManager);
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (loggerManager is null)
+        {
+            throw new ArgumentNullException(nameof(loggerManager));
+        }
+
         builder.AddProvider(loggerManager.XunitLoggerProvider);
         return builder;
     }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,11 +3,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,7 +9,6 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,6 +9,7 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -21,15 +21,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="Mono.Cecil" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Mono.Cecil" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Maris.Logging.Testing\Maris.Logging.Testing.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-  </PropertyGroup>
 
 </Project>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Mono.Cecil" Condition="'$(TargetFramework)' == 'net48'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -28,4 +28,8 @@
     <ProjectReference Include="..\..\src\Maris.Logging.Testing\Maris.Logging.Testing.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
 </Project>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Mono.Cecil" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -21,7 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="Mono.Cecil" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\..\src\Maris.Logging.Testing\Maris.Logging.Testing.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
 </Project>

--- a/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerTest.cs
+++ b/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerTest.cs
@@ -10,7 +10,7 @@ public class XunitLoggerTest
         get
         {
             var data = new TheoryData<LogLevel>();
-            foreach (var logLevel in Enum.GetValues<LogLevel>())
+            foreach (LogLevel logLevel in Enum.GetValues(typeof(LogLevel)))
             {
                 data.Add(logLevel);
             }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Maris.Logging.Testing のターゲットフレームワークを`net472;net80;net90`に変更しました。
- Maris.Logging.Testingとテストプロジェクトが参照している以下パッケージについて、`Microsoft.Extensions.~ doesn't support net472 and has not been tested with it.`の警告を抑制しました。
  - Microsoft.Extensions.Diagnostics.Testing 8.0.0
  - Microsoft.Extensions.Compliance.Abstractions 8.0.0 (推移的に参照しているパッケージ)
  - Microsoft.Extensions.Telemetry.Abstractions 8.0.0 (推移的に参照しているパッケージ)
- CIパイプラインのテストを`net472`で実行できるようにしました。
- テストプロジェクトにMono.Cecilの参照を追加しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/microsoft/codecoverage/issues/162

<!-- I want to review in Japanese. -->