### PR TITLE
NuGet へのデプロイ方法をよりセキュアな方法に変更する

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -102,7 +102,7 @@ jobs:
           name: ${{ matrix.packaging_project_name }}
 
       - name: NuGet に OIDC ログインして一時 API キーを発行
-        uses: NuGet/login@v1
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.0.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }} # NuGet の組織名ではなくユーザー名を設定する必要があります。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- 短命（約1時間）でよりセキュアな API キーを用いて NuGet へデプロイするようワークフローを変更しました。

### NuGet 側
- このリポジトリと紐づくように Trusted Publishing を設定しました。

### GitHub 側
- Secrets に NuGet へのデプロイ権限を持つユーザーのユーザー名 `NUGET_USER` を設定しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/

<!-- I want to review in Japanese. -->