### PR TITLE
Maris.ComponentModel.Annotationsのリリースノート自動生成設定を追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,13 @@ changelog:
         labels:
           - dependencies
           - 内部の改善
+    - title: ':newspaper: [Maris.ComponentModel.Annotations](https://www.nuget.org/packages/Maris.ComponentModel.Annotations) features'
+      labels:
+        - 'target: Maris.ComponentModel.Annotations'
+      exclude:
+        labels:
+          - dependencies
+          - 内部の改善
     - title: ':label: :purple_circle: NuGet package dependencies'
       labels:
         - nuget


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

Maris.ComponentModel.AnnotationsのGitHub Releaseでのリリースノートが自動生成されるように設定しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->