### PR TITLE
パイプライン上での npm ci 実行時のライフサイクルスクリプト実行を無効に変更

### DIFF
--- a/.github/workflows/lint-documents.yml
+++ b/.github/workflows/lint-documents.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: npm パッケージのインストール
         shell: bash
-        run: npm ci
+        run: npm ci --ignore-scripts
   
       - name: Linter の処理開始
         shell: bash


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- ライフサイクルスクリプト経由で発火するマルウェアが混入した場合に発火を防ぎます。

- ignore-scripts をした場合に、 cypress と esbuild が正常に動作しなくなる可能性がありますが、cypress はパイプラインで実行しておらず esbuild も開発環境で TS をそのまま実行するためにしか使っていないはずなので、パイプラインに限って言えば動作は問題ないはずです。

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://blog.flatt.tech/entry/bitwarden_compromise#Lifecycle-script-%E3%81%AE%E7%84%A1%E5%8A%B9%E5%8C%96

<!-- I want to review in Japanese. -->